### PR TITLE
Basic configuration for testing added

### DIFF
--- a/.flask_env
+++ b/.flask_env
@@ -1,6 +1,8 @@
 CS_HOST_PORT=5000
 CS_HOST_IP=127.0.0.1
 DATABASE_URL=postgresql://lv-python-mc:575@127.0.0.1:5482/Realty_DB
+DATABASE_TEST_URL=postgresql://lv-python-mc:575@127.0.0.1:5482/test
+FLASK_CONFIG_MODE=config.DevelopmentConfig
 REDIS_IP=127.0.0.1
 REDIS_PORT=6379
 FLASK_ENV=development

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,0 @@
-"""
-Top level module
-"""
-import service_api

--- a/config.py
+++ b/config.py
@@ -12,7 +12,7 @@ class Config:
     DEBUG = False
     TESTING = False
     CSRF_ENABLED = True
-    SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
+    SQLALCHEMY_DATABASE_URL = os.environ['DATABASE_URL']
 
 
 class ProductionConfig(Config):
@@ -43,3 +43,4 @@ class TestingConfig(Config):
     Config for testing
     """
     TESTING = True
+    SQLALCHEMY_DATABASE_URL = os.environ['DATABASE_TEST_URL']

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ autopep8==1.5.5
 alembic==1.5.7
 pylint==2.7.2
 pre-commit
+pytest==6.2.3

--- a/docker-test.yaml
+++ b/docker-test.yaml
@@ -1,0 +1,17 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:13.2
+    ports:
+      - "5482:5432"
+    environment:
+      - POSTGRES_USER=lv-python-mc
+      - POSTGRES_PASSWORD=575
+      - POSTGRES_DB=test
+
+
+  redis:
+    image: redis:6.2
+    ports:
+      - "6379:6379"

--- a/service_api/__init__.py
+++ b/service_api/__init__.py
@@ -30,12 +30,12 @@ class UnicodeApi(Api):
 
 
 flask_app = Flask(__name__)
-flask_app.config.from_object("config.DevelopmentConfig")
+flask_app.config.from_object(os.environ.get("FLASK_CONFIG_MODE", "config.DevelopmentConfig"))
 api_ = UnicodeApi(flask_app)
 
 # connecting to DB
-engine = create_engine(os.environ["DATABASE_URL"])
-metadata = MetaData()
+engine = create_engine(flask_app.config.get("SQLALCHEMY_DATABASE_URL"))
+metadata = MetaData(bind=engine)
 Base = declarative_base(metadata)
 Session_factory = sessionmaker(bind=engine)
 session = Session_factory()

--- a/service_api/constants.py
+++ b/service_api/constants.py
@@ -8,9 +8,9 @@ URLS = {
         "GET_REALTY_URL": "/realty",
         "GET_STATES_URL": "/states",
         "GET_STATES_BY_ID_URL": "/states/<state_id>",
-        "GET_REALTY_TYPES_URL": "/realty_types/",
+        "GET_REALTY_TYPES_URL": "/realty_types",
         "GET_REALTY_TYPE_BY_ID_URL": "/realty_type/<realty_type_id>",
-        "GET_OPERATION_TYPES_URL": "/operation_types/",
+        "GET_OPERATION_TYPES_URL": "/operation_types",
         "GET_OPERATION_TYPE_BY_ID_URL": "/operation_type/<operation_type_id>"
     },
     "GRABBING": {

--- a/service_api/grabbing_api/resources.py
+++ b/service_api/grabbing_api/resources.py
@@ -26,21 +26,14 @@ class CoreDataLoaderResource(Resource):
         Load data to db based on input params
 
         Example of get request to load data to DB
-
-            http://127.0.0.1:5000/grabbing/core_data?cities=144&states
-
-            This request trigger fetching states and cities where state_id=144
+            /grabbing/core_data?cities=144&states
+        This request trigger fetching states and cities where state_id=144
 
         All possible entites to load is located in metadata_for_fetching_DB_core.json
-
-        Only cities can take additional params that will be represented as list.
-
-            http://127.0.0.1:5000/grabbing/core_data?operation_types&cities=5&cities=144
-
-            Here cities: [5, 144] and all cities from such states (if state exists) will be loaded
-
+        Only cities can take additional params that will be represented as a list.
+            /grabbing/core_data?operation_types&cities=5&cities=144
+        Here cities: [5, 144] and all cities from such states (if state exists) will be loaded.
         By default, if none parameters for city is passed, cities from ALL states will be loaded!!!
-
         """
         params = {key: list(filter(lambda x: x != "", value)) for key, value in request.args.to_dict(False).items()}
         factory = LoadersFactory()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""
+Config module for pytest
+"""
+import pytest
+from service_api import Base, engine, session
+
+
+@pytest.fixture
+def reset_db():
+    """
+    Main setup and teardown fixture that is reseting database
+    """
+    Base.metadata.create_all(engine)
+    yield session
+    session.close()
+    Base.metadata.drop_all(engine)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,3 @@
 """
 Config module for pytest
 """
-import pytest
-from service_api import Base, engine, session
-
-
-@pytest.fixture
-def reset_db():
-    """
-    Main setup and teardown fixture that is reseting database
-    """
-    Base.metadata.create_all(engine)
-    yield session
-    session.close()
-    Base.metadata.drop_all(engine)

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,24 @@
+"""
+Testing module
+"""
+
+from sqlalchemy.orm import Session
+from service_api.models import State
+
+
+def test_state_creation(reset_db: Session):
+    """
+    Adding state to db and checking if name is inserted right
+    """
+    data = {
+        "name": "TestStateName",
+        "original_id": 3,
+    }
+    state = State(**data)
+
+    reset_db.add(state)
+    reset_db.commit()
+
+    state = reset_db.query(State).first()
+
+    assert state.name == data["name"]

--- a/tests/test.py
+++ b/tests/test.py
@@ -2,11 +2,24 @@
 Testing module
 """
 
-from sqlalchemy.orm import Session
 from service_api.models import State
+from service_api import session, Base, engine
 
 
-def test_state_creation(reset_db: Session):
+def setup_function():
+    """
+    Create all table in DB
+    """
+    Base.metadata.create_all(engine)
+
+def teardown_function():
+    """
+    Closes session if its open and drop database
+    """
+    session.close()
+    Base.metadata.drop_all(engine)
+
+def test_state_creation():
     """
     Adding state to db and checking if name is inserted right
     """
@@ -16,9 +29,9 @@ def test_state_creation(reset_db: Session):
     }
     state = State(**data)
 
-    reset_db.add(state)
-    reset_db.commit()
+    session.add(state)
+    session.commit()
 
-    state = reset_db.query(State).first()
+    state = session.query(State).first()
 
     assert state.name == data["name"]


### PR DESCRIPTION
Closes #117 

Basic test config added with separate docker-test.yaml.

To run test:
- set FLASK_CONFIG_MODE=config.TestingConfig
- docker compose -f docker-test.yaml up
- purest tests/*