### PR TITLE
DB reseting functionality addded to manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -113,17 +113,25 @@ def clear_db() -> None:
 
 
 @cli.command("resetDB")
-def reset_db() -> None:
+@click.option("--drop-only", is_flag=True, default=False, help="drops all tables only")
+@click.option("--create-only", is_flag=True, default=False, help="create all tables only")
+def reset_db(drop_only, create_only) -> None:
     """
     Drops all tables inherited from Base
     and recreates them
     """
+    if not(drop_only or create_only):
+        # by default input params are false so need to inver them
+        drop_only, create_only = True, True
+
     if input("Are you sure? (y/n)\n").lower() == "y":
-        LOGGER.info("Dropping db...")
-        Base.metadata.drop_all(engine)
-        LOGGER.info("Tables droped!")
-        Base.metadata.create_all(engine)
-        LOGGER.info("Tables created!")
+        if drop_only:
+            LOGGER.info("Dropping db...")
+            Base.metadata.drop_all(engine)
+            LOGGER.info("Tables droped!")
+        if create_only:
+            Base.metadata.create_all(engine)
+            LOGGER.info("Tables created!")
 
 
 if __name__ == "__main__":

--- a/manage.py
+++ b/manage.py
@@ -7,7 +7,8 @@ from typing import Dict
 
 import click
 
-from service_api import Base, session_scope, flask_app, LOGGER
+
+from service_api import Base, session_scope, flask_app, LOGGER, engine
 from service_api.exceptions import MetaDataError
 from service_api.utils.db import CoreDataLoadersFactory
 
@@ -109,6 +110,20 @@ def clear_db() -> None:
             session.query(table).delete()
             LOGGER.debug("%s cleared!", table)
     LOGGER.debug("ALL table cleared")
+
+
+@cli.command("resetDB")
+def reset_db() -> None:
+    """
+    Drops all tables inherited from Base
+    and recreates them
+    """
+    if input("Are you sure? (y/n)\n").lower() == "y":
+        LOGGER.info("Dropping db...")
+        Base.metadata.drop_all(engine)
+        LOGGER.info("Tables droped!")
+        Base.metadata.create_all(engine)
+        LOGGER.info("Tables created!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added ability to drop and recreate tables
Closes #194 

Usage:
python manage.py resetDB [OPTIONS]
   Drops all tables inherited from Base and recreates them

Options:
  --drop-only    drops all tables only
  --create-only  create all tables only